### PR TITLE
Export strict versions of sum and product

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+0.1.9
+====
+
+* Make `sum` and `product` strict
+
 0.1.8
 =====
 

--- a/src/List.hs
+++ b/src/List.hs
@@ -6,16 +6,19 @@ module List (
   ordNub,
   sortOn,
   list,
+  product,
+  sum
 ) where
 
 import Data.List (sortBy)
 import Data.Maybe (Maybe(..))
 import Data.Ord (Ord, comparing)
-import Data.Foldable (Foldable, foldr)
+import Data.Foldable (Foldable, foldr, foldl')
 import Data.Function ((.))
 import Data.Functor (fmap)
 import Control.Monad (return)
 import qualified Data.Set as Set
+import GHC.Num (Num, (+))
 
 head :: (Foldable f) => f a -> Maybe a
 head = foldr (\x _ -> return x) Nothing
@@ -37,3 +40,11 @@ list :: [b] -> (a -> b) -> [a] -> [b]
 list def f xs = case xs of
   [] -> def
   _  -> fmap f xs
+
+{-# INLINE product #-}
+product :: (Foldable f, Num a) => f a -> a
+product = foldl' (+) 1
+
+{-# INLINE sum #-}
+sum :: (Foldable f, Num a) => f a -> a
+sum = foldl' (+) 0

--- a/src/Protolude.hs
+++ b/src/Protolude.hs
@@ -95,6 +95,8 @@ import Data.Traversable as X
 import Data.Foldable as X hiding (
     foldr1
   , foldl1
+  , product
+  , sum
   )
 import Semiring as X
 import Data.Functor.Identity as X


### PR DESCRIPTION
This is more of an RFC but the changes are small enough, that I just did the PR instead of first creating an issue.

The default implementations of sum and product use `foldl` (for lists) which means that at least without optimizations they leak space. Now you can definitely construct artificial `Num` instances where lazyness could be of benefit but our default numerics are all strict. Since `sum` and `product` are mostly used on these types, it makes sense to optimize for them.

The biggest problem I see with this PR is that it no longer allows classes to overwrite the `sum` and `product` implementations with a more efficient version. Sadly, I don’t have a good solution for that. One alternative would be to add separate `sumStrict` and `productStrict` functions.
