### PR TITLE
Add (<&&>),(<||>)

### DIFF
--- a/src/Bool.hs
+++ b/src/Bool.hs
@@ -7,10 +7,13 @@ module Bool (
 , ifM
 , guardM
 , bool
+, (<&&>)
+, (<||>)
 ) where
 
-import Data.Bool (Bool)
+import Data.Bool (Bool, (&&), (||))
 import Data.Function (flip)
+import Control.Applicative(Applicative, liftA2)
 import Control.Monad (Monad, MonadPlus, when, unless, guard, (>>=), (=<<))
 
 bool :: a -> a -> Bool -> a
@@ -29,3 +32,15 @@ ifM p x y = p >>= \b -> if b then x else y
 
 guardM :: MonadPlus m => m Bool -> m ()
 guardM f = guard =<< f
+
+infixr 3 <&&> -- same as (&&)
+-- | '&&' lifted to an Applicative.
+(<&&>) :: Applicative a => a Bool -> a Bool -> a Bool
+(<&&>) = liftA2 (&&)
+{-# INLINE (<&&>) #-}
+
+infixr 2 <||> -- same as (||)
+-- | '||' lifted to an Applicative.
+(<||>) :: Applicative a => a Bool -> a Bool -> a Bool
+(<||>) = liftA2 (||)
+{-# INLINE (<||>) #-}


### PR DESCRIPTION
Similar to `classy-prelude`: https://github.com/snoyberg/classy-prelude/pull/125

Discussion here: https://github.com/snoyberg/classy-prelude/issues/109

Also defined in the [ghc](https://www.stackage.org/haddock/lts-8.3/ghc-8.0.2/Util.html) package. The ghc package is a bit painful to incorporate in script  (using `runghc`) so I still believe the PR would be  a nice addition in a prelude.

Inline pragma copied from the classy-prelude PR. I don't know if it is necessary (the ghc package does not have one)