### PR TITLE
Update `safe` upper bound for ghc >=7.8.0

### DIFF
--- a/protolude.cabal
+++ b/protolude.cabal
@@ -78,10 +78,10 @@ library
     mtl-compat       >= 0.2  && <0.3
 
   if impl(ghc >= 7.8.0)
-    build-depends:       
-      safe             >= 0.3  && <0.3.12
+    build-depends:
+      safe             >= 0.3  && <0.3.15
   else
-    build-depends:       
+    build-depends:
       safe             >= 0.3  && <0.3.10
 
   hs-source-dirs:      src


### PR DESCRIPTION
`0.3.14` is used in stack lts-8.x