### PR TITLE
Update protolude.cabal

### DIFF
--- a/protolude.cabal
+++ b/protolude.cabal
@@ -82,7 +82,7 @@ library
 
   if impl(ghc >= 7.8.0)
     build-depends:
-      safe             >= 0.3  && <0.3.15
+      safe             >= 0.3  && <0.3.16
   else
     build-depends:
       safe             >= 0.3  && <0.3.10


### PR DESCRIPTION
Increase upperbound of safe.

This allows the master git version to build using the latest stackage`lts-8.23`