### PR TITLE
Added RealFloat

### DIFF
--- a/src/Base.hs
+++ b/src/Base.hs
@@ -29,6 +29,7 @@ import GHC.Float as X (
     Float(..)
   , Double(..)
   , Floating (..)
+  , RealFloat(..)
   , showFloat
   , showSignedFloat
   )


### PR DESCRIPTION
Added RealFloat to GHC.Float import list.

I find it hard to track down the exact change in base, but `isNaN` was exported from protolude and isn't in testing for ghc-8.2.