### PR TITLE
Debug trace functions now output to stderr

### DIFF
--- a/src/Debug.hs
+++ b/src/Debug.hs
@@ -18,20 +18,21 @@ import Control.Monad (Monad, return)
 
 import qualified Base as P
 import Error (error)
-import Show (Print, putStrLn)
+import Show (Print, hPutStrLn)
 
+import System.IO(stderr)
 import System.IO.Unsafe (unsafePerformIO)
 
 {-# WARNING trace "'trace' remains in code" #-}
 trace :: Print b => b -> a -> a
 trace string expr = unsafePerformIO (do
-    putStrLn string
+    hPutStrLn stderr string
     return expr)
 
 {-# WARNING traceIO "'traceIO' remains in code" #-}
 traceIO :: Print b => b -> a -> P.IO a
 traceIO string expr = do
-    putStrLn string
+    hPutStrLn stderr string
     return expr
 
 {-# WARNING traceShow "'traceShow' remains in code" #-}


### PR DESCRIPTION
Hello,

Thanks for writing Protolude!

It is conventional for debugging/monitoring output to appear on standard error. This is because standard error is immediately flushed, and because standard error may be different than standard output(it may go to a terminal rather than the program's output file).