### PR TITLE
Support GHC-8.2.2

### DIFF
--- a/src/Protolude/Error.hs
+++ b/src/Protolude/Error.hs
@@ -3,6 +3,9 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE ExistentialQuantification #-}
+#if ( __GLASGOW_HASKELL__ >= 800 )
+{-# LANGUAGE TypeInType #-}
+#endif
 
 #if MIN_VERSION_base(4,9,0)
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}


### PR DESCRIPTION
When compiling with GHC 8.2.2-rc1:

```
src/Error.hs:25:17: error:
    Variable ‘r’ used as both a kind and a type
    Did you intend to use TypeInType?
   |
25 | error :: forall (r :: RuntimeRep) . forall (a :: TYPE r) . HasCallStack => Text -> a
   |                 ^^^^^^^^^^^^^^^^^
```

`TypeInType` should be enabled, see GHC issue 14121
https://ghc.haskell.org/trac/ghc/ticket/14121