### PR TITLE
Add throwE & catchE

### DIFF
--- a/src/Protolude.hs
+++ b/src/Protolude.hs
@@ -281,15 +281,19 @@ import Control.Monad.Reader as X (
   , runReader
   , runReaderT
   )
+  )
+
+import Control.Monad.Trans.Except as X (
+    throwE
+  , catchE
+  )
 
 import Control.Monad.Except as X (
     MonadError
   , Except
   , ExceptT(ExceptT)
   , throwError
-  , throwE
   , catchError
-  , catchE
   , runExcept
   , runExceptT
   )

--- a/src/Protolude.hs
+++ b/src/Protolude.hs
@@ -281,7 +281,6 @@ import Control.Monad.Reader as X (
   , runReader
   , runReaderT
   )
-  )
 
 import Control.Monad.Trans.Except as X (
     throwE

--- a/src/Protolude.hs
+++ b/src/Protolude.hs
@@ -287,7 +287,9 @@ import Control.Monad.Except as X (
   , Except
   , ExceptT(ExceptT)
   , throwError
+  , throwE
   , catchError
+  , catchE
   , runExcept
   , runExceptT
   )


### PR DESCRIPTION
My understanding is that `throwError` & `catchError` are deprecated (maybe we should remove them?)