### PR TITLE
add mapExcept(T) and withExcept(T)

### DIFF
--- a/src/Protolude.hs
+++ b/src/Protolude.hs
@@ -295,6 +295,10 @@ import Control.Monad.Except as X (
   , catchError
   , runExcept
   , runExceptT
+  , mapExcept
+  , mapExceptT
+  , withExcept
+  , withExceptT
   )
 
 import Control.Monad.Trans as X (


### PR DESCRIPTION
Since we already export functions like `withState` and the names don’t clash
with anything, we export these transformation functions as well.
Every function from Control.Monad.Except is now exported, the user doesn’t need
to import it for common error handling tasks.

fixes #75 
Tested by `cabal build`ing it.