### PR TITLE
Remove note about error function from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ import GHC.Show (Show(..))
 Automatic deriving of ``Show`` for your types is still supported since the class
 is in scope by default.
 
-* **Partial functions like ``undefined`` and ``error`` raise compiler warnings on
+* **Partial functions like ``undefined`` raise compiler warnings on
   usage.**
 
 This is by design. For fatal uncatchable errors use the provided ``panic``


### PR DESCRIPTION
The README still mentions the error function which is not exported anymore. 

Related: #86