### PR TITLE
'Protolude.Error.error' produces call stacks

### DIFF
--- a/src/Protolude/Error.hs
+++ b/src/Protolude/Error.hs
@@ -27,7 +27,7 @@ import GHC.Exception (errorCallWithCallStackException)
 
 {-# WARNING error "'error' remains in code" #-}
 error :: forall (r :: RuntimeRep) . forall (a :: TYPE r) . HasCallStack => Text -> a
-error s = raise# (errorCallWithCallStackException (unpack s) ?callstack)
+error s = raise# (errorCallWithCallStackException (unpack s) ?callStack)
 
 #elif MIN_VERSION_base(4,7,0)
 -- Basic Call Stack with callsite.


### PR DESCRIPTION
Calling `Protolude.Error.error` will now include the call stack in the `ErrorCall` that is raised. Before this was not the case because we used the wrong implicit variable.