### PR TITLE
Update link to exported functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,7 @@ import Protolude
 Exported Functions
 ------------------
 
-The list of exports is given in the [Symbols.md](./Symbols.md) file. Haddock
-unfortunately breaks in the presence of module reexports and is unable to render
-documentation.
+The list of exports can be browsed [here](http://hackage.haskell.org/package/protolude-0.2.3/docs/Protolude.html).
 
 Dependencies
 ------------


### PR DESCRIPTION
The file `Symbols.md` doesn't exist anymore in the repository.

In the meantime Haddock fixed a long standing bug that allows Hackage to display all exported symbols now so we can now link to it.

Closes #105