### PR TITLE
Bump bounds on base and ghc-prim to work on GHC 9.0.x

### DIFF
--- a/protolude.cabal
+++ b/protolude.cabal
@@ -77,11 +77,11 @@ library
   build-depends:
       array                >=0.4  && <0.6
     , async                >=2.0  && <2.3
-    , base                 >=4.6  && <4.15
+    , base                 >=4.6  && <4.16
     , bytestring           >=0.10 && <0.11
     , containers           >=0.5  && <0.7
     , deepseq              >=1.3  && <1.5
-    , ghc-prim             >=0.3  && <0.7
+    , ghc-prim             >=0.3  && <0.8
     , hashable             >=1.2  && <1.4
     , mtl                  >=2.1  && <2.3
     , mtl-compat           >=0.2  && <0.3


### PR DESCRIPTION
Addresses #127.