### PR TITLE
0.3.1 Release Candidate

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["9.0.1", "8.10.1", "8.8.1", "8.6.5", "8.6.4", "8.6.3", "8.6.2", "8.4.4", "8.2.2", "8.0.2"]
-        cabal: ["3.0", "3.2"]
+        ghc: ['9.2', '9.0.1', '8.10.1', '8.8.1', '8.6.5', '8.6.4', '8.6.3', '8.6.2', '8.4.4', '8.2.2', '8.0.2', '7.10.3']
+        cabal: ['latest', 3.2]
+      fail-fast: false
     env:
       CONFIG: "--enable-tests --enable-benchmarks"
     steps:

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -25,15 +25,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.0.1
+          - compiler: ghc-7.6.3
             allow-failure: false
-          - compiler: ghc-8.10.1
+          - compiler: ghc-7.8.4
             allow-failure: false
-          - compiler: ghc-8.8.1
-            allow-failure: false
-          - compiler: ghc-8.6.1
-            allow-failure: false
-          - compiler: ghc-8.4.1
+          - compiler: ghc-7.10.3
             allow-failure: false
       fail-fast: false
     steps:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
-Unreleased
+0.3.1
 =====
-
+* GHC 9.0.1 and 9.2.1 support
+* Add `HasCallStack` to unsafe* functions.
 * Banish `String` on `readMaybe` and `readEither`.
 
 0.3.0

--- a/README.md
+++ b/README.md
@@ -30,31 +30,23 @@ Design points:
 
 Supports:
 
- * GHC 7.6.1
- * GHC 7.6.2
  * GHC 7.6.3
- * GHC 7.8.1
- * GHC 7.8.2
- * GHC 7.8.3
  * GHC 7.8.4
- * GHC 7.10.1
- * GHC 7.10.2
  * GHC 7.10.3
- * GHC 8.0.1
  * GHC 8.0.2
- * GHC 8.2.1
+ * GHC 8.2.2
  * GHC 8.4.1
+ * GHC 8.4.4
  * GHC 8.6.1
+ * GHC 8.6.4
+ * GHC 8.6.5
  * GHC 8.8.1
  * GHC 8.10.1
+ * GHC 9.0.1
+ * GHC 9.2.1
 
 Stack LTS:
 
-* lts-4.x
-* lts-5.x
-* lts-6.x
-* lts-7.x
-* lts-8.x
 * lts-9.x
 * lts-10.x
 * lts-11.x
@@ -63,6 +55,7 @@ Stack LTS:
 * lts-14.x
 * lts-15.x
 * lts-16.x
+* lts-17.x
 
 Usage
 -----
@@ -108,7 +101,7 @@ tracks Stack LTS resolver.
 | -----------         |   -------- |  -------- |
 | array               |        0.4 |       0.6 |
 | async               |        2.0 |       2.3 |
-| base                |        4.6 |      4.15 |
+| base                |        4.6 |      4.16 |
 | bytestring          |       0.10 |      0.11 |
 | containers          |        0.5 |       0.7 |
 | deepseq             |        1.3 |       1.5 |
@@ -210,7 +203,7 @@ and base.
 
 There is a massive test suite that tests all versions of GHC 7.6 - GHC HEAD
 alongside all Stack resolvers to ensure no regressions. Any pull requests or
-patch has to pass the 40 integrity checks before being considered. Any pull
+patch has to pass the 47 integrity checks before being considered. Any pull
 request must keep the export list consistent across GHC and Base version and not
 have any accidental symbol dropping or drift without updating the export golden
 tests.
@@ -219,4 +212,4 @@ License
 -------
 
 Released under the MIT License.
-Copyright (c) 2016-2020, Stephen Diehl
+Copyright (c) 2016-2022, Stephen Diehl

--- a/protolude.cabal
+++ b/protolude.cabal
@@ -1,27 +1,20 @@
 name:               protolude
-version:            0.3.0
+version:            0.3.1
 synopsis:           A small prelude.
 description:        A sensible set of defaults for writing custom Preludes.
 homepage:           https://github.com/sdiehl/protolude
 license:            MIT
 license-file:       LICENSE
 author:             Stephen Diehl
-maintainer:         stephen.m.diehl@gmail.com
-copyright:          2016-2020 Stephen Diehl
+maintainer:         adamwespiser@gmail.com, stephen.m.diehl@gmail.com
+copyright:          2016-2022 Stephen Diehl
 category:           Prelude
 build-type:         Simple
 cabal-version:      >=1.10
 bug-reports:        https://github.com/sdiehl/protolude/issues
 tested-with:
-  GHC ==7.6.1
-   || ==7.6.2
-   || ==7.6.3
-   || ==7.8.1
-   || ==7.8.2
-   || ==7.8.3
+  GHC ==7.6.3
    || ==7.8.4
-   || ==7.10.1
-   || ==7.10.2
    || ==7.10.3
    || ==8.0.1
    || ==8.2.1
@@ -30,6 +23,7 @@ tested-with:
    || ==8.8.1
    || ==8.10.1
    || ==9.0.1
+   || ==9.2.1
 
 extra-source-files:
   README.md
@@ -78,16 +72,16 @@ library
   build-depends:
       array                >=0.4  && <0.6
     , async                >=2.0  && <2.3
-    , base                 >=4.6  && <4.16
-    , bytestring           >=0.10 && <0.11
+    , base                 >=4.6  && <4.17
+    , bytestring           >=0.10 && <0.11.4
     , containers           >=0.5  && <0.7
     , deepseq              >=1.3  && <1.5
-    , ghc-prim             >=0.3  && <0.8
-    , hashable             >=1.2  && <1.4
+    , ghc-prim             >=0.3  && <0.9
+    , hashable             >=1.2  && <1.5
     , mtl                  >=2.1  && <2.3
     , mtl-compat           >=0.2  && <0.3
     , stm                  >=2.4  && <2.6
-    , text                 >=1.2  && <1.3
+    , text                 >=1.2  && <2.1
     , transformers         >=0.2  && <0.6
     , transformers-compat  >=0.4  && <0.8
 

--- a/src/Protolude.hs
+++ b/src/Protolude.hs
@@ -270,14 +270,19 @@ import Data.List.NonEmpty as List (
 import Data.Semigroup as Semigroup (
     Semigroup(sconcat, stimes)
   , WrappedMonoid
-  , Option(..)
-  , option
   , diff
   , cycle1
   , stimesMonoid
   , stimesIdempotent
   , stimesIdempotentMonoid
   , mtimesDefault
+  )
+#endif
+
+#if MIN_VERSION_base(4,9,0) && !MIN_VERSION_base(4,16,0)
+import Data.Semigroup as Semigroup (
+    Option(..)
+  , option
   )
 #endif
 

--- a/src/Protolude/Unsafe.hs
+++ b/src/Protolude/Unsafe.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE Unsafe #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
@@ -12,13 +13,21 @@ module Protolude.Unsafe (
   unsafeRead,
 ) where
 
-import Protolude.Base (Int, HasCallStack)
+import Protolude.Base (Int)
+
+#if ( __GLASGOW_HASKELL__ >= 800 )
+import Protolude.Base (HasCallStack)
+#endif
 import Data.Char (Char)
 import Text.Read (Read, read)
 import qualified Data.List as List
 import qualified Data.Maybe as Maybe
 import qualified Control.Exception as Exc
 
+unsafeThrow :: Exc.Exception e => e -> a
+unsafeThrow = Exc.throw
+
+#if ( __GLASGOW_HASKELL__ >= 800 )
 unsafeHead :: HasCallStack => [a] -> a
 unsafeHead = List.head
 
@@ -37,8 +46,30 @@ unsafeFromJust = Maybe.fromJust
 unsafeIndex :: HasCallStack => [a] -> Int -> a
 unsafeIndex = (List.!!)
 
-unsafeThrow :: Exc.Exception e => e -> a
-unsafeThrow = Exc.throw
-
 unsafeRead :: (HasCallStack, Read a) => [Char] -> a
 unsafeRead = Text.Read.read
+#endif
+
+
+#if ( __GLASGOW_HASKELL__ < 800 )
+unsafeHead :: [a] -> a
+unsafeHead = List.head
+
+unsafeTail :: [a] -> [a]
+unsafeTail = List.tail
+
+unsafeInit :: [a] -> [a]
+unsafeInit = List.init
+
+unsafeLast :: [a] -> a
+unsafeLast = List.last
+
+unsafeFromJust :: Maybe.Maybe a -> a
+unsafeFromJust = Maybe.fromJust
+
+unsafeIndex :: [a] -> Int -> a
+unsafeIndex = (List.!!)
+
+unsafeRead :: Read a => [Char] -> a
+unsafeRead = Text.Read.read
+#endif


### PR DESCRIPTION
Cutting a release candidate, 0.3.1 to get protolude for ghc version 9 on hackage.

1) Adds back support for ghc-7.X.Y that was lost when updating from Travis to Github workflows. Not sure if these tests will pass.
2) Adds support for ghc 9.2.1 in new CI test.
3) Updates docs to reflect exact versions being tested.