### PR TITLE
Re-export isInfixOf, isSuffixOf from Data.List, Issue #119

### DIFF
--- a/src/Protolude.hs
+++ b/src/Protolude.hs
@@ -311,6 +311,8 @@ import Data.List as List (
   , break
   , intercalate
   , isPrefixOf
+  , isInfixOf
+  , isSuffixOf
   , drop
   , filter
   , reverse


### PR DESCRIPTION
https://github.com/protolude/protolude/issues/119