### PR TITLE
Don't export missing Option on GHC 9.2

### DIFF
--- a/src/Protolude.hs
+++ b/src/Protolude.hs
@@ -270,8 +270,10 @@ import Data.List.NonEmpty as List (
 import Data.Semigroup as Semigroup (
     Semigroup(sconcat, stimes)
   , WrappedMonoid
+#if !MIN_VERSION_base(4,16,0)
   , Option(..)
   , option
+#endif
   , diff
   , cycle1
   , stimesMonoid


### PR DESCRIPTION
> Remove Data.Semigroup.Option and the accompanying option function.

-- https://hackage.haskell.org/package/base-4.16.0.0/changelog#41600-nov-2021