### PR TITLE
Update dependencies

### DIFF
--- a/protolude.cabal
+++ b/protolude.cabal
@@ -24,6 +24,7 @@ tested-with:
    || ==8.10.1
    || ==9.0.1
    || ==9.2.2
+   || ==9.6.1
 
 extra-source-files:
   README.md
@@ -67,17 +68,17 @@ library
   build-depends:
       array                >=0.4  && <0.6
     , async                >=2.0  && <2.3
-    , base                 >=4.6  && <4.18
+    , base                 >=4.6  && <4.20
     , bytestring           >=0.10 && <0.12
-    , containers           >=0.5  && <0.7
+    , containers           >=0.5  && <0.8
     , deepseq              >=1.3  && <1.5
-    , ghc-prim             >=0.3  && <0.10
+    , ghc-prim             >=0.3  && <0.11
     , hashable             >=1.2  && <1.5
-    , mtl                  >=2.1  && <2.3
+    , mtl                  >=2.1  && <2.4
     , mtl-compat           >=0.2  && <0.3
     , stm                  >=2.4  && <2.6
     , text                 >=1.2  && <2.1
-    , transformers         >=0.2  && <0.6
+    , transformers         >=0.2  && <0.7
     , transformers-compat  >=0.4  && <0.8
 
   if !impl(ghc >=8.0)


### PR DESCRIPTION
Builds correctly with ghc-9.6.1

Would also love to see a new release (or a Hackage revision) with these changes.

These changes will allow us to drop a bunch of `allow-newer` stanzas in the `cabal.project` file of our `ghc-9.6` builds.