### PR TITLE
make unsnoc handle infinite lists

### DIFF
--- a/src/Protolude.hs
+++ b/src/Protolude.hs
@@ -952,7 +952,7 @@ unsnoc = Foldable.foldr go Nothing
   where
     go x mxs = Just (case mxs of
        Nothing -> ([], x)
-       Just (xs, e) -> (x:xs, e))
+       Just ~(xs, e) -> (x:xs, e))
 
 -- | Apply a function n times to a given value
 applyN :: Int -> (a -> a) -> a -> a


### PR DESCRIPTION
Before:

    ghci> take 10 . fst <$> unsnoc [1..]
    Just *** Exception: stack overflow

After:

    ghci> take 10 . fst <$> unsnoc [1..]
    Just [1,2,3,4,5,6,7,8,9,10]